### PR TITLE
Fix admins in courses requesting module progressions for other users as well as themselves

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -24,6 +24,7 @@ globals:
   module: false
   jest: false
   __DEV__: false
+  ENV: false
 rules:
   linebreak-style:
     - error

--- a/client/apps/atomic_search_widget/app.js
+++ b/client/apps/atomic_search_widget/app.js
@@ -82,7 +82,7 @@ function allModuleProgress(courseIds, cb) {
   const promises = courseIds.map(id =>
     new Promise((resolve) => {
       $.ajax({
-        url: `/courses/${id}/modules/progressions.json`,
+        url: `/courses/${id}/modules/progressions.json?user_id=${ENV.current_user_id}`,
         dataType: 'text',
       }).done((data) => {
         const json = JSON.parse(data.replace(/^while\(1\);/, ''));


### PR DESCRIPTION
This will only affect admin users, as the Canvas controller only uses the user_id parameter for them.