### PR TITLE
Only return cached results if all course ids requested are cached

### DIFF
--- a/client/apps/atomic_search_widget/app.js
+++ b/client/apps/atomic_search_widget/app.js
@@ -64,19 +64,37 @@ function cacheResults(results) {
   }
 }
 
-function allModuleProgress(courseIds, cb) {
-  // first check if we already have it in local storage
+function getCachedResults() {
   try {
     let stored = localStorage.getItem('atomicjoltModuleProgress');
     if (stored) {
       stored = JSON.parse(stored);
+
       if (Date.now() - stored.time < 3600000) { // one hour
-        cb(stored.data);
-        return;
+        return stored.data;
       }
     }
+
+    return {};
   } catch (e) {
     console.warn('failed to read from localStorage', e);
+    return {};
+  }
+}
+
+function allModuleProgress(courseIds, cb) {
+  const cachedProgress = getCachedResults();
+
+  const missingCourseIds = [];
+  courseIds.forEach((id) => {
+    if (!cachedProgress[id]) {
+      missingCourseIds.push(id);
+    }
+  });
+
+  if (missingCourseIds.length === 0) {
+    cb(cachedProgress);
+    return;
   }
 
   const promises = courseIds.map(id =>


### PR DESCRIPTION
Search is changing to only request the progressions for the current course, and only request progressions for all courses when the user searches all courses. This handles caching when the course ids being sent to the search widget can change.