### PR TITLE
fix the locking logic

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -398,8 +398,8 @@ function addWidget(addToDOM, attemptNumber) {
 }
 
 // an instance of the script is already running
-if (!atomicSearchConfig.locked) {
-  atomicSearchConfig.locked = true;
+if (!window.ATOMIC_SEARCH_LOCKED) {
+  window.ATOMIC_SEARCH_LOCKED = true;
   ajEnableListener();
   addWidget(addBigWidget, 0);
   addWidget(addSmallWidget, 0);


### PR DESCRIPTION
atomicSearchConfig is local to the script in many cases, so modifying it isn't always effective.