### PR TITLE
fix duplicate custom elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ npm-debug.log
 coverage/
 
 cypress.env.json
+/cypress

--- a/README.md
+++ b/README.md
@@ -37,11 +37,20 @@ Run webpack hot reload server:
   `yarn hot`
 
 Release a production build to the S3 website bucket
-env is dev, beta, or prod
+env is dev, beta, or prod:
   `yarn release [env]`
 
 Run a linter over the project:
   `yarn lint`
+
+Run a linter over the project:
+  `yarn lint`
+
+Run Cypress tests:
+  `yarn test`
+
+Cypress has many command line options to choose from, if you want to use those,
+run it directly, for example: `yarn cypress run --help`
 
 ## Deploy
 If you have multiple aws profiles and need to use a specific one you can do so by setting the AWS_PROFILE

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-#Atomic Search Widget [![Build Status](https://travis-ci.org/atomicjolt/react_client_starter_app.svg?branch=master)](https://travis-ci.org/atomicjolt/react_client_starter_app) [![Coverage Status](https://coveralls.io/repos/github/atomicjolt/react_client_starter_app/badge.svg?branch=coveralls)](https://coveralls.io/github/atomicjolt/react_client_starter_app?branch=coveralls)
------------------------
+# Atomic Search Widget [![Build Status](https://travis-ci.org/atomicjolt/react_client_starter_app.svg?branch=master)](https://travis-ci.org/atomicjolt/react_client_starter_app) [![Coverage Status](https://coveralls.io/repos/github/atomicjolt/react_client_starter_app/badge.svg?branch=coveralls)](https://coveralls.io/github/atomicjolt/react_client_starter_app?branch=coveralls)
 This application adds a search widget to Canvas.
 
 
-#Install into Canvas:
------------------------
+## Install into Canvas:
 [Follow these instructions to install into Canvas](Installation_Instructions.md)
 
 
-#Getting Started with Development:
------------------------
+## Getting Started with Development:
 
 Make sure to install git, npm and yarn before you start then:
 
@@ -29,15 +26,13 @@ Make sure to install git, npm and yarn before you start then:
    subaccount or on test or beta canvas). It's a small
    snippet that simply loads the js from the webpack server.
 
-#Check for updates
------------
+## Check for updates
 Inside the client directory run:
 
   `yarn upgrade-interactive`
 
 
-#Scripts:
------------------------
+## Scripts:
 Run webpack hot reload server:
   `yarn hot`
 
@@ -48,13 +43,11 @@ env is dev, beta, or prod
 Run a linter over the project:
   `yarn lint`
 
-#Deploy
------------------------
+## Deploy
 If you have multiple aws profiles and need to use a specific one you can do so by setting the AWS_PROFILE
 i.e.
 AWS_PROFILE=atomicjolt yarn release dev
 
 
-License and attribution
------------------------
+## License and attribution
 MIT

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "node ./esbuild.js prod",
     "hot": "node ./esbuild.js dev",
     "lint": "eslint src",
-    "release": "yarn build && node ./bin/deploy.js"
+    "release": "yarn build && node ./bin/deploy.js",
+    "test": "cypress run"
   },
   "repository": {
     "type": "git",

--- a/src/desktop_widget.js
+++ b/src/desktop_widget.js
@@ -1,4 +1,9 @@
-import { SEARCH_SVG, initWidget, BaseWidget } from './widget_common';
+import {
+  SEARCH_SVG,
+  initWidget,
+  BaseWidget,
+  registerWidget,
+} from './widget_common';
 
 function html(cssClass, placeholder) {
   return `<div class="ajas-search-widget ${cssClass}">
@@ -21,4 +26,4 @@ export default class AtomicSearchDesktopWidget extends BaseWidget {
   }
 }
 
-customElements.define('atomic-search-desktop-widget', AtomicSearchDesktopWidget);
+registerWidget('atomic-search-desktop-widget', AtomicSearchDesktopWidget);

--- a/src/mobile_widget.js
+++ b/src/mobile_widget.js
@@ -3,6 +3,7 @@ import {
   SEARCH_SVG,
   CLOSE_SVG,
   BaseWidget,
+  registerWidget,
 } from './widget_common';
 
 function html(placeholder) {
@@ -37,4 +38,4 @@ export default class AtomicSearchMobileWidget extends BaseWidget {
   }
 }
 
-customElements.define('atomic-search-mobile-widget', AtomicSearchMobileWidget);
+registerWidget('atomic-search-mobile-widget', AtomicSearchMobileWidget);

--- a/src/widget_common.js
+++ b/src/widget_common.js
@@ -45,3 +45,11 @@ export class BaseWidget extends HTMLElement {
     this.shadowRoot.querySelector('input').value = text;
   }
 }
+
+// multiple instances of the script can be running in some cases, this prevents
+// that from throwing an error
+export function registerWidget(name, klass) {
+  if (!customElements.get(name)) {
+    customElements.define(name, klass);
+  }
+}


### PR DESCRIPTION
I found this error running the cypress tests. When you have multiple search widgets, (installed in multiple subaccounts), it tries to register the widget multiple times. This throws an error, though the widget continues to function. This will prevent the error from being thrown.

I'm also adding some docs and scripts for cypress