### PR TITLE
Only show equella dropdown to teachers/admins and fix query param issues

### DIFF
--- a/src/query_params.js
+++ b/src/query_params.js
@@ -1,0 +1,50 @@
+export function getQuery() {
+  const query = window.location.search.substring(1);
+  return new URLSearchParams(query);
+}
+
+const VAR_MAPPING = {
+  ajsearch: 'search',
+  ajpage: 'page',
+  ajcontext: 'context',
+  ajfilters: 'filters',
+};
+
+// sends current query vars to Search, this happens when the app first loads
+export function sendQueryVariables(source) {
+  const query = getQuery();
+
+  const message = { subject: 'atomicjolt.searchParams' };
+
+  Object.keys(VAR_MAPPING).forEach(queryName => {
+    const messageName = VAR_MAPPING[queryName];
+    const value = query.get(queryName);
+    if (value) {
+      message[messageName] = value;
+    }
+  });
+
+  source.postMessage(JSON.stringify(message), '*');
+}
+
+// when Search sends updated variables, we store them as query params
+export function receiveQueryVariables(message) {
+  const query = getQuery();
+
+  Object.keys(VAR_MAPPING).forEach(queryName => {
+    const messageName = VAR_MAPPING[queryName];
+    const value = message[messageName];
+    if (value) {
+      query.set(queryName, value);
+    } else {
+      query.delete(queryName);
+    }
+  });
+
+  const newState = `?${query.toString()}`;
+  window.history.pushState(
+    null,
+    '',
+    newState
+  );
+}

--- a/src/widget_common.js
+++ b/src/widget_common.js
@@ -95,10 +95,12 @@ export function registerWidget(name, klass) {
 const equellaRoles = ['teacher', 'admin', 'root_admin'];
 
 function userHasEquella() {
+  if (!atomicSearchConfig.hasEquella) return false;
+
   // These roles don't seem to change based on the current course/account, so it
   // may not always be accurate
   const roles = window.ENV.current_user_roles || [];
-  return atomicSearchConfig.hasEquella && roles.some(role => equellaRoles.includes(role));
+  return roles.some(role => equellaRoles.includes(role));
 }
 
 export const getEquellaDomData = () => {

--- a/src/widget_common.js
+++ b/src/widget_common.js
@@ -92,8 +92,18 @@ export function registerWidget(name, klass) {
   }
 }
 
+const equellaRoles = ['teacher', 'admin', 'root_admin'];
+
+function userHasEquella() {
+  // These roles don't seem to change based on the current course/account, so it
+  // may not always be accurate
+  const roles = window.ENV.current_user_roles || [];
+  return atomicSearchConfig.hasEquella && roles.some(role => equellaRoles.includes(role));
+}
+
 export const getEquellaDomData = () => {
-  const dropdownHtml = atomicSearchConfig.hasEquella ? `
+  const withEquella = userHasEquella();
+  const dropdownHtml = withEquella ? `
     <button id="menu-target" type="button" aria-label="open dropdown" class="ajas-search-widget__btn--caret">
       ${CARET_SVG}
     </button>
@@ -103,7 +113,7 @@ export const getEquellaDomData = () => {
     </div>
   ` : '';
 
-  const equellaClass = atomicSearchConfig.hasEquella ? 'ajas-search-widget--equella' : '';
+  const equellaClass = withEquella ? 'ajas-search-widget--equella' : '';
 
   return { dropdownHtml, equellaClass };
 };


### PR DESCRIPTION
I discovered some issues with query param handling that I introduced in the last PR. It was always sending every value to act even if they were null/empty. It did the same when updating the url bar based on messages from act