### PR TITLE
remove aria-label check, since it doesn't work in RCE launch

### DIFF
--- a/src/expand_lti_launch.js
+++ b/src/expand_lti_launch.js
@@ -6,10 +6,8 @@ export default function handleTrayExpand(event) {
   );
   if (sender) {
     const dialog = sender.closest('[role=dialog]');
-    
-    if (dialog.getAttribute('aria-label') === 'Atomic Author') {
-      dialog.parentElement.style.width = '888px';
-      dialog.parentElement.style.maxWidth = '100%';
-    }
+
+    dialog.parentElement.style.width = '888px';
+    dialog.parentElement.style.maxWidth = '100%';
   }
 }


### PR DESCRIPTION
This check was added so it wouldn't shift the modal launch over to the left, we no longer use that launch, so it's unnecessary, and the RCE launch has a different aria-label, so it was causing that launch to not expand