### PR TITLE
only run widget initialization code once

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -38,3 +38,6 @@ rules:
     - as-needed
   import/extensions: 0
   no-plusplus: 0
+  # it's useful to prefix custom element attributes with a '_' so they don't
+  # collide with built in functions
+  no-underscore-dangle: 0

--- a/src/canvas/desktop_widget.js
+++ b/src/canvas/desktop_widget.js
@@ -25,7 +25,7 @@ function html(cssClass, placeholder) {
 }
 
 export default class AtomicSearchDesktopWidget extends BaseWidget {
-  connectedCallback() {
+  _onConnect() {
     const { cssClass, placeholder } = this.dataset;
     const htmlText = html(cssClass, placeholder);
 

--- a/src/canvas/mobile_widget.js
+++ b/src/canvas/mobile_widget.js
@@ -29,7 +29,7 @@ function html(placeholder) {
 }
 
 export default class AtomicSearchMobileWidget extends BaseWidget {
-  connectedCallback() {
+  _onConnect() {
     const { placeholder } = this.dataset;
     const htmlText = html(placeholder);
 

--- a/src/canvas/widget_common.js
+++ b/src/canvas/widget_common.js
@@ -60,6 +60,12 @@ export function initWidget(widget, htmlText) {
 }
 
 export class BaseWidget extends HTMLElement {
+  connectedCallback() {
+    if (this._alreadyConnected) return;
+    this._onConnect();
+    this._alreadyConnected = true;
+  }
+
   updateSearchText(newValue) {
     // undefined will get turned into text, so ignore all falsey values
     const text = newValue || '';


### PR DESCRIPTION
Canvas does something that causes connectedCallback to run multiple times on one element. This was throwing an error, but doesn't seem to impact the widget